### PR TITLE
Fix mobile scroll in EndScene

### DIFF
--- a/public/charts.html
+++ b/public/charts.html
@@ -1,135 +1,141 @@
-<div id="leaderboard" class="w-[300px] h-[320px] bg-white/20 shadow p-3 rounded">
-    <h1 class="text-center font-semibold mb-2">Leaderboard</h1>
-    <table class="w-full table-fixed py-2 border-collapse">
-        <tbody>
-            <tr>
-                <td id="tr1-rank" style="width: 20%"></td>
-                <td id="tr1-name" class="truncate" style="width: 60%"></td>
-                <td id="tr1-score" style="width: 20%; text-align: right"></td>
+<div id="charts" class="grid place-items-center w-[400px] h-[560px] overflow-auto pt-8 pb-20">
+    <div id="results" class="text-center text-white mb-8 text-xl">
+        <p id="name" class="mb-6"></p>
+        <button id="retry"><img src="./RetryButton.png" width="125" alt="Retry button"/></button>
+    </div>
+    <div id="leaderboard" class="w-[300px] h-[320px] bg-white/20 shadow p-3 rounded">
+        <h1 class="text-center font-semibold mb-2">Leaderboard</h1>
+        <table class="w-full table-fixed py-2 border-collapse">
+            <tbody>
+                <tr>
+                    <td id="tr1-rank" style="width: 20%"></td>
+                    <td id="tr1-name" class="truncate" style="width: 60%"></td>
+                    <td id="tr1-score" style="width: 20%; text-align: right"></td>
 
-            </tr>
-            <tr>
-                <td id="tr2-rank"></td>
-                <td id="tr2-name" class="truncate"></td>
-                <td id="tr2-score" style="width: 14%; text-align: right"></td>
-            </tr>
-            <tr>
-                <td id="tr3-rank"></td>
-                <td id="tr3-name" class="truncate"></td>
-                <td id="tr3-score" style="width: 14%; text-align: right"></td>
-            </tr>
-            <tr>
-                <td id="tr4-rank"></td>
-                <td id="tr4-name" class="truncate"></td>
-                <td id="tr4-score" style="width: 14%; text-align: right"></td>
-            </tr>
-            <tr>
-                <td id="tr5-rank"></td>
-                <td id="tr5-name" class="truncate"></td>
-                <td id="tr5-score" style="width: 14%; text-align: right"></td>
-            </tr>
-            <tr>
-                <td id="tr6-rank"></td>
-                <td id="tr6-name" class="truncate"></td>
-                <td id="tr6-score" style="width: 14%; text-align: right"></td>
-            </tr>
-            <tr>
-                <td id="tr7-rank"></td>
-                <td id="tr7-name" class="truncate"></td>
-                <td id="tr7-score" style="width: 14%; text-align: right"></td>
-            </tr>
-            <tr>
-                <td id="tr8-rank"></td>
-                <td id="tr8-name" class="truncate"></td>
-                <td id="tr8-score" style="width: 14%; text-align: right"></td>
-            </tr>
-            <tr>
-                <td id="tr9-rank"></td>
-                <td id="tr9-name" class="truncate"></td>
-                <td id="tr9-score" style="width: 14%; text-align: right"></td>
-            </tr>
-            <tr>
-                <td id="tr10-rank"></td>
-                <td id="tr10-name" class="truncate"></td>
-                <td id="tr10-score" style="width: 14%; text-align: right"></td>
-            </tr>
-        </tbody>
-    </table>
-</div>
+                </tr>
+                <tr>
+                    <td id="tr2-rank"></td>
+                    <td id="tr2-name" class="truncate"></td>
+                    <td id="tr2-score" style="width: 14%; text-align: right"></td>
+                </tr>
+                <tr>
+                    <td id="tr3-rank"></td>
+                    <td id="tr3-name" class="truncate"></td>
+                    <td id="tr3-score" style="width: 14%; text-align: right"></td>
+                </tr>
+                <tr>
+                    <td id="tr4-rank"></td>
+                    <td id="tr4-name" class="truncate"></td>
+                    <td id="tr4-score" style="width: 14%; text-align: right"></td>
+                </tr>
+                <tr>
+                    <td id="tr5-rank"></td>
+                    <td id="tr5-name" class="truncate"></td>
+                    <td id="tr5-score" style="width: 14%; text-align: right"></td>
+                </tr>
+                <tr>
+                    <td id="tr6-rank"></td>
+                    <td id="tr6-name" class="truncate"></td>
+                    <td id="tr6-score" style="width: 14%; text-align: right"></td>
+                </tr>
+                <tr>
+                    <td id="tr7-rank"></td>
+                    <td id="tr7-name" class="truncate"></td>
+                    <td id="tr7-score" style="width: 14%; text-align: right"></td>
+                </tr>
+                <tr>
+                    <td id="tr8-rank"></td>
+                    <td id="tr8-name" class="truncate"></td>
+                    <td id="tr8-score" style="width: 14%; text-align: right"></td>
+                </tr>
+                <tr>
+                    <td id="tr9-rank"></td>
+                    <td id="tr9-name" class="truncate"></td>
+                    <td id="tr9-score" style="width: 14%; text-align: right"></td>
+                </tr>
+                <tr>
+                    <td id="tr10-rank"></td>
+                    <td id="tr10-name" class="truncate"></td>
+                    <td id="tr10-score" style="width: 14%; text-align: right"></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 
-<div id="playerStats" class="w-[300px] h-[130px] bg-white/20 shadow p-3 rounded mt-4">
-    <h1 class="text-center font-semibold mb-2">Player Stats</h1>
-    <table class="w-full table-fixed py-2 border-collapse">
-        <thead>
-            <tr>
-                <th class="text-left align-bottom font-light text-sm">Games</th>
-                <th class="text-left align-bottom font-light text-sm">Total Score</th>
-                <th class="text-left align-bottom font-light text-sm">Avg. Score</th>
-                <th class="text-left align-bottom font-light text-sm">Max. Score</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td id="n_games"></td>
-                <td id="total_score"></td>
-                <td id="avg_score"></td>
-                <td id="max_score"></td>
-            </tr>
-        </tbody>
-    </table>
-</div>
+    <div id="playerStats" class="w-[300px] h-[130px] bg-white/20 shadow p-3 rounded mt-4">
+        <h1 class="text-center font-semibold mb-2">Player Stats</h1>
+        <table class="w-full table-fixed py-2 border-collapse">
+            <thead>
+                <tr>
+                    <th class="text-left align-bottom font-light text-sm">Games</th>
+                    <th class="text-left align-bottom font-light text-sm">Total Score</th>
+                    <th class="text-left align-bottom font-light text-sm">Avg. Score</th>
+                    <th class="text-left align-bottom font-light text-sm">Max. Score</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td id="n_games"></td>
+                    <td id="total_score"></td>
+                    <td id="avg_score"></td>
+                    <td id="max_score"></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 
-<div id="lastPlayed" class="w-[300px] h-[340px] bg-white/20 shadow p-3 rounded mt-4">
-    <h1 class="text-center font-semibold mb-2">Recent Games</h1>
-    <table class="w-full py-2 border-collapse">
-        <thead>
-            <tr>
-                <th class="text-left font-light text-sm">Time</th>
-                <th class="text-left font-light text-sm">Score</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td id="tr1-time"></td>
-                <td id="tr1-score"></td>
+    <div id="lastPlayed" class="w-[300px] h-[340px] bg-white/20 shadow p-3 rounded mt-4">
+        <h1 class="text-center font-semibold mb-2">Recent Games</h1>
+        <table class="w-full py-2 border-collapse">
+            <thead>
+                <tr>
+                    <th class="text-left font-light text-sm">Time</th>
+                    <th class="text-left font-light text-sm">Score</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td id="tr1-time"></td>
+                    <td id="tr1-score"></td>
 
-            </tr>
-            <tr>
-                <td id="tr2-time"></td>
-                <td id="tr2-score"></td>
-            </tr>
-            <tr>
-                <td id="tr3-time"></td>
-                <td id="tr3-score"></td>
-            </tr>
-            <tr>
-                <td id="tr4-time"></td>
-                <td id="tr4-score"></td>
-            </tr>
-            <tr>
-                <td id="tr5-time"></td>
-                <td id="tr5-score"></td>
-            </tr>
-            <tr>
-                <td id="tr6-time"></td>
-                <td id="tr6-score"></td>
-            </tr>
-            <tr>
-                <td id="tr7-time"></td>
-                <td id="tr7-score"></td>
-            </tr>
-            <tr>
-                <td id="tr8-time"></td>
-                <td id="tr8-score"></td>
-            </tr>
-            <tr>
-                <td id="tr9-time"></td>
-                <td id="tr9-score"></td>
-            </tr>
-            <tr>
-                <td id="tr10-time"></td>
-                <td id="tr10-score"></td>
-            </tr>
-        </tbody>
-    </table>
+                </tr>
+                <tr>
+                    <td id="tr2-time"></td>
+                    <td id="tr2-score"></td>
+                </tr>
+                <tr>
+                    <td id="tr3-time"></td>
+                    <td id="tr3-score"></td>
+                </tr>
+                <tr>
+                    <td id="tr4-time"></td>
+                    <td id="tr4-score"></td>
+                </tr>
+                <tr>
+                    <td id="tr5-time"></td>
+                    <td id="tr5-score"></td>
+                </tr>
+                <tr>
+                    <td id="tr6-time"></td>
+                    <td id="tr6-score"></td>
+                </tr>
+                <tr>
+                    <td id="tr7-time"></td>
+                    <td id="tr7-score"></td>
+                </tr>
+                <tr>
+                    <td id="tr8-time"></td>
+                    <td id="tr8-score"></td>
+                </tr>
+                <tr>
+                    <td id="tr9-time"></td>
+                    <td id="tr9-score"></td>
+                </tr>
+                <tr>
+                    <td id="tr10-time"></td>
+                    <td id="tr10-score"></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 </div>

--- a/src/scenes/EndGameScene.js
+++ b/src/scenes/EndGameScene.js
@@ -23,55 +23,7 @@ export default class EndGameScene extends Phaser.Scene {
     }
 
     create() {
-        this.getDataFromTinybird().then(() => {
-            const text = this.add.text(
-                this.cameras.main.width / 2,
-                60,
-                `${this.session.name},\n\nyou scored ${this.score} point${this.score !== 1 ? "s" : ""}!`,
-                {
-                    align: "center",
-                    fontFamily: 'Pixel Operator',
-                }
-            );
-
-            // Set origin to center for proper alignment
-            text.setOrigin(0.5);
-
-            this.add
-                .image(200, 135, "RetryButton")
-                .setScale(.5)
-                .setInteractive({ cursor: "pointer" })
-                .on("pointerup", () => {
-                    this.retry();
-                });
-
-            const topLimit = 0; // Set the top limit for scrolling
-
-            //Enable scrolling
-            const handleScroll = (deltaY) => {
-                this.cameras.main.scrollY = Phaser.Math.Clamp(
-                    this.cameras.main.scrollY + (deltaY * 0.5),
-                    topLimit,
-                    Number.MAX_SAFE_INTEGER
-                );
-            };
-
-            // Mouse wheel scrolling
-            window.addEventListener("wheel", (event) => {
-                event.preventDefault();
-                handleScroll(event.deltaY);
-            }, { passive: false });
-
-            // Touch scrolling
-            this.input.on("pointermove", (pointer) => {
-                pointer.event.preventDefault();
-                if (pointer.isDown) {
-                    const deltaY = pointer.velocity.y * 0.5;
-                    handleScroll(-deltaY);
-                }
-            });
-
-        });
+        this.getDataFromTinybird();
     }
 
     retry() {
@@ -94,9 +46,20 @@ export default class EndGameScene extends Phaser.Scene {
             this.session.name
         );
         const charts = this.add
-            .dom(50, 200)
+            .dom(0, 0)
             .createFromCache("charts")
             .setOrigin(0, 0);
+        
+        // Set name and score
+        charts.getChildByID("name").innerHTML = `${
+            this.session.name
+        },<br/>you scored ${this.score} point${this.score !== 1 ? "s" : ""}!`;
+
+        // Add event to DOM button
+        charts.getChildByID("retry").addEventListener("click", () => {
+            this.retry();
+        });
+
         return Promise.all([
             get_data_from_tinybird(endpoints.top_10_url)
                 .then((r) => this.buildTopTen(charts, r))

--- a/src/style.css
+++ b/src/style.css
@@ -27,3 +27,13 @@ body {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+/* Hide scrollbar for end scene */
+#charts::-webkit-scrollbar {
+  display: none;
+}
+
+#charts {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+}


### PR DESCRIPTION
## Problem

In the EndScene, mobile scroll was not working properly. If you scroll by clicking outside the results table it worked, but if you scroll inside it didn't.

## Cause

The EndScene was a mix of DOM elements (the tables inside charts.html file) and phaser components (title and retry button that were painted inside the canvas).
The DOM elements where the ones causing the overflow and it was not correctly handled.

## Solution

Unify everything into the DOM elements so the scrolling mess is more simple to handle and there is no need to add any event listener to phaser. The only thing we need is the native scroll handling of the browser.
So the title and retry button are added into the charts.html file, and all the related code is remove from the EndScene promise.