### PR TITLE
Fix DealScene layout after changes in charts.html

### DIFF
--- a/public/charts.html
+++ b/public/charts.html
@@ -1,7 +1,8 @@
 <div id="charts" class="grid place-items-center w-[400px] h-[560px] overflow-auto pt-8 pb-20">
-    <div id="results" class="text-center text-white mb-8 text-xl">
-        <p id="name" class="mb-6"></p>
-        <button id="retry"><img src="./RetryButton.png" width="125" alt="Retry button"/></button>
+    <div class="text-center text-white mb-12 text-xl leading-5 font-semibold px-8">
+        <p id="title" class="mb-8"></p>
+        <button id="offer-button"><img src="./OfferButton.png" width="230" alt="Claim offer button"/></button>
+        <button id="retry-button"><img src="./RetryButton.png" width="125" alt="Retry button"/></button>
     </div>
     <div id="leaderboard" class="w-[300px] h-[320px] bg-white/20 shadow p-3 rounded">
         <h1 class="text-center font-semibold mb-2">Leaderboard</h1>

--- a/src/scenes/DealScene.js
+++ b/src/scenes/DealScene.js
@@ -18,57 +18,15 @@ export default class DealScene extends Phaser.Scene {
     }
 
     init(data) {
-        this.session = data.session;
-        this.score = data.score;
+        this.session = {
+            name: 'julia',
+            id: '123'
+        };
+        this.score = 999;
     }
 
     create() {
-        this.getDataFromTinybird().then(() => {
-            const text = this.add.text(
-                this.cameras.main.width / 2,
-                100,
-                `${this.session.name},\n\nFlappy is tired of dying :(\n\nPurchase this power-up to\nactivate easy mode!`,
-                {
-                    align: "center",
-                }
-            );
-
-            // Set origin to center for proper alignment
-            text.setOrigin(0.5);
-            this.add
-                .image(200, 220, "OfferButton")
-                .setScale(.5)
-                .setInteractive({ cursor: "pointer" })
-                .on("pointerup", () => {
-                    this.buyPowerUp();
-                });
-
-            const topLimit = 0; // Set the top limit for scrolling
-
-            //Enable scrolling
-            const handleScroll = (deltaY) => {
-                this.cameras.main.scrollY = Phaser.Math.Clamp(
-                    this.cameras.main.scrollY + (deltaY * 0.5),
-                    topLimit,
-                    Number.MAX_SAFE_INTEGER
-                );
-            };
-
-            // Mouse wheel scrolling
-            window.addEventListener("wheel", (event) => {
-                event.preventDefault();
-                handleScroll(event.deltaY);
-            }, { passive: false });
-
-            // Touch scrolling
-            this.input.on("pointermove", (pointer) => {
-                pointer.event.preventDefault();
-                if (pointer.isDown) {
-                    const deltaY = pointer.velocity.y * 0.5;
-                    handleScroll(-deltaY);
-                }
-            });
-        });
+        this.getDataFromTinybird();
     }
 
     buyPowerUp() {
@@ -96,9 +54,21 @@ export default class DealScene extends Phaser.Scene {
         );
 
         const charts = this.add
-            .dom(50, 300)
+            .dom(0, 0)
             .createFromCache("charts")
             .setOrigin(0, 0);
+
+        // Set title
+        charts.getChildByID('title').innerHTML = `${this.session.name},<br/><br/>Flappy is tired of dying :(<br/><br/>Purchase this power-up to<br/>activate easy mode!`
+        
+        // Add event to DOM button
+        charts.getChildByID("offer-button").addEventListener("click", () => {
+            this.buyPowerUp();
+        });
+
+        charts.getChildByID("retry-button").remove();
+
+        
         return Promise.all([
             get_data_from_tinybird(endpoints.top_10_url)
                 .then((r) => this.buildTopTen(charts, r))

--- a/src/scenes/DealScene.js
+++ b/src/scenes/DealScene.js
@@ -18,11 +18,8 @@ export default class DealScene extends Phaser.Scene {
     }
 
     init(data) {
-        this.session = {
-            name: 'julia',
-            id: '123'
-        };
-        this.score = 999;
+        this.session = data.session;
+        this.score = data.score;
     }
 
     create() {

--- a/src/scenes/EndGameScene.js
+++ b/src/scenes/EndGameScene.js
@@ -51,14 +51,16 @@ export default class EndGameScene extends Phaser.Scene {
             .setOrigin(0, 0);
         
         // Set name and score
-        charts.getChildByID("name").innerHTML = `${
+        charts.getChildByID("title").innerHTML = `${
             this.session.name
-        },<br/>you scored ${this.score} point${this.score !== 1 ? "s" : ""}!`;
+        },<br/><br/>you scored ${this.score} point${this.score !== 1 ? "s" : ""}!`;
 
         // Add event to DOM button
-        charts.getChildByID("retry").addEventListener("click", () => {
+        charts.getChildByID("retry-button").addEventListener("click", () => {
             this.retry();
         });
+
+        charts.getChildByID("offer-button").remove();
 
         return Promise.all([
             get_data_from_tinybird(endpoints.top_10_url)


### PR DESCRIPTION
## Problem
The DealScene layout is broken

A screenshot of the problem:
<img width="380" alt="image" src="https://github.com/tinybirdco/flappy-tinybird/assets/3521323/86b3bb86-065e-459b-83ab-8a5748880dfb">

## Cause

My previous PR #43 :)

## Solution

DealScene and EndScene share charts.html DOM elemnts.
In this PR we apply apply the same kind of changes: move title and Claim offer button to charts.html file.
Based on the scene we hide the retry or the claim offer button to correctly build the scene